### PR TITLE
GOV-558 remove contributing page from the specs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,7 +1,6 @@
 # Table of contents
 
 * [GovStack](README.md)
-* [Contributing](contributing.md)
 * [Code of Conduct](code-of-conduct.md)
 * [Architecture and Nonfunctional Requirements](architecture-and-nonfunctional-requirements/README.md)
   * [2 Description](architecture-and-nonfunctional-requirements/description.md)


### PR DESCRIPTION
We will add the content of this page to the “give feedback” menu item so it is right next to the place people are contributing in the first instance. Keeping the actual file in place in this PR so that we can refer to it.